### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Phug/AbstractCompilerTest.php
+++ b/tests/Phug/AbstractCompilerTest.php
@@ -4,10 +4,11 @@ namespace Phug\Test;
 
 use Exception;
 use JsPhpize\JsPhpize;
+use PHPUnit\Framework\TestCase;
 use Phug\Compiler;
 use Phug\CompilerEvent;
 
-abstract class AbstractCompilerTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractCompilerTest extends TestCase
 {
     /**
      * @var Compiler

--- a/tests/Phug/Compiler/Locator/FileLocatorTest.php
+++ b/tests/Phug/Compiler/Locator/FileLocatorTest.php
@@ -60,7 +60,7 @@ class FileLocatorTest extends AbstractCompilerTest
 
         $locator = new FileLocator();
         self::assertSame(__FILE__, $locator->locate(__FILE__, [], []));
-        self::assertSame(null, $locator->locate('foo.pug', [], []));
-        self::assertSame(null, $locator->locate('foo.pug', [], []));
+        self::assertNull($locator->locate('foo.pug', [], []));
+        self::assertNull($locator->locate('foo.pug', [], []));
     }
 }

--- a/tests/Phug/CompilerModuleTest.php
+++ b/tests/Phug/CompilerModuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test;
 
+use PHPUnit\Framework\TestCase;
 use Phug\Compiler;
 use Phug\Compiler\Event\CompileEvent;
 use Phug\Compiler\Event\ElementEvent;
@@ -14,7 +15,7 @@ use Phug\Parser\Node\ElementNode;
 /**
  * @coversDefaultClass Phug\AbstractCompilerModule
  */
-class CompilerModuleTest extends \PHPUnit_Framework_TestCase
+class CompilerModuleTest extends TestCase
 {
     /**
      * @group modules

--- a/tests/Phug/CompilerTest.php
+++ b/tests/Phug/CompilerTest.php
@@ -362,7 +362,7 @@ class CompilerTest extends AbstractCompilerTest
         self::assertTrue($compiler->hasFilter('4'));
         self::assertSame('A', $compiler->getFilter('a'));
         self::assertSame('B', $compiler->getFilter('b'));
-        self::assertSame(null, $compiler->getFilter('c'));
+        self::assertNull($compiler->getFilter('c'));
         self::assertSame(42, $compiler->getFilter('21'));
         self::assertSame(0, $compiler->getFilter('0'));
 
@@ -374,7 +374,7 @@ class CompilerTest extends AbstractCompilerTest
         $compiler->unsetFilter('c');
 
         self::assertFalse($compiler->hasFilter('c'));
-        self::assertSame(null, $compiler->getFilter('c'));
+        self::assertNull($compiler->getFilter('c'));
     }
 
     /**


### PR DESCRIPTION
I've refactored some tests with [`assertNull`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertNull) method and use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`.